### PR TITLE
Feature/welsh lang support

### DIFF
--- a/api/metadata.go
+++ b/api/metadata.go
@@ -44,16 +44,18 @@ func (api *CantabularMetadataExtractorAPI) getMetadata(w http.ResponseWriter, r 
 	ctx := r.Context()
 	params := mux.Vars(r)
 
-	// TODO handle  params["lang"]
+	if params["lang"] == "" {
+		params["lang"] = "en"
+	}
 
-	mt, dimensions, err := api.GetMetadataTable(ctx, params["datasetID"])
+	mt, dimensions, err := api.GetMetadataTable(ctx, params["datasetID"], params["lang"])
 	if err != nil {
 		log.Error(ctx, err.Error(), err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	md, err := api.GetMetadataDataset(ctx, params["cantdataset"], dimensions)
+	md, err := api.GetMetadataDataset(ctx, params["cantdataset"], dimensions, params["lang"])
 	if err != nil {
 		log.Error(ctx, err.Error(), err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -74,9 +76,9 @@ func (api *CantabularMetadataExtractorAPI) getMetadata(w http.ResponseWriter, r 
 	w.Write(json)
 }
 
-func (api *CantabularMetadataExtractorAPI) GetMetadataTable(ctx context.Context, cantDataset string) (*cantabular.MetadataTableQuery, []string, error) {
+func (api *CantabularMetadataExtractorAPI) GetMetadataTable(ctx context.Context, cantDataset string, lang string) (*cantabular.MetadataTableQuery, []string, error) {
 
-	req := cantabular.MetadataTableQueryRequest{Variables: []string{cantDataset}}
+	req := cantabular.MetadataTableQueryRequest{Variables: []string{cantDataset}, Lang: lang}
 
 	var dims []string
 	mt, err := api.CantExtAPI.MetadataTableQuery(context.Background(), req)
@@ -95,11 +97,12 @@ func (api *CantabularMetadataExtractorAPI) GetMetadataTable(ctx context.Context,
 	return mt, dims, err
 }
 
-func (api *CantabularMetadataExtractorAPI) GetMetadataDataset(ctx context.Context, cantDataset string, dimensions []string) (*cantabular.MetadataDatasetQuery, error) {
+func (api *CantabularMetadataExtractorAPI) GetMetadataDataset(ctx context.Context, cantDataset string, dimensions []string, lang string) (*cantabular.MetadataDatasetQuery, error) {
 
 	req := cantabular.MetadataDatasetQueryRequest{}
 	req.Dataset = cantDataset
 	req.Variables = dimensions
+	req.Lang = lang
 
 	md, err := api.CantExtAPI.MetadataDatasetQuery(ctx, req)
 

--- a/api/metadata_test.go
+++ b/api/metadata_test.go
@@ -29,7 +29,7 @@ func TestGetMetadataTable(t *testing.T) {
 		}
 		Convey("GetMetadataTable method should return correct dimensions", func() { // XXX
 			expected := []string{"Region", "Ethnic Group", "Sex", "Age"}
-			_, dims, err := cantMetadataExtractorApi.GetMetadataTable(ctx, "Teaching-Dataset")
+			_, dims, err := cantMetadataExtractorApi.GetMetadataTable(ctx, "Teaching-Dataset", "en")
 			if err != nil {
 				t.Error(err)
 			}
@@ -57,7 +57,7 @@ func TestGetMetadataDataset(t *testing.T) {
 		}
 
 		Convey("getDimensions method should return correct dimensions", func() { // XXX
-			md, err := cantMetadataExtractorApi.GetMetadataDataset(ctx, "Teaching-Dataset", []string{"Age", "Sex"})
+			md, err := cantMetadataExtractorApi.GetMetadataDataset(ctx, "Teaching-Dataset", []string{"Age", "Sex"}, "en")
 			if err != nil {
 				t.Fail()
 			}

--- a/go.mod
+++ b/go.mod
@@ -12,13 +12,13 @@ replace github.com/prometheus/client_golang => github.com/prometheus/client_gola
 replace gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.0
 
 // point at feature/cantabular-metadata-runtime-terror2 branch which we don't want to merge yet
-replace github.com/ONSdigital/dp-api-clients-go/v2 => github.com/ONSdigital/dp-api-clients-go/v2 v2.120.1-0.20220527134344-85877ce00f3f
+replace github.com/ONSdigital/dp-api-clients-go/v2 => github.com/ONSdigital/dp-api-clients-go/v2 v2.120.1-0.20220530141822-fa6cc6c85e88
 
 // DO NOT COMMIT XXX
 //replace github.com/ONSdigital/dp-api-clients-go/v2 => /home/steve/work/pubmisc/cantj/dp-api-clients-go
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.120.1-0.20220527134344-85877ce00f3f
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.120.1-0.20220530141822-fa6cc6c85e88
 	github.com/ONSdigital/dp-component-test v0.7.0
 	github.com/ONSdigital/dp-healthcheck v1.3.0
 	github.com/ONSdigital/dp-net v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.120.1-0.20220527134344-85877ce00f3f h1:N/SrAZmWtUSpApqQlPrNjuEvJ/q07jLIjLLfZvpykCg=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.120.1-0.20220527134344-85877ce00f3f/go.mod h1:tHRq65gA340CYpkHIRMrrxiLS8IlAl7nTeFr07ukJgo=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.120.1-0.20220530141822-fa6cc6c85e88 h1:uOyVoVX9sSUmUKy/ZIXJitMj+wJJwFWSB3T7VIzyfLo=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.120.1-0.20220530141822-fa6cc6c85e88/go.mod h1:tHRq65gA340CYpkHIRMrrxiLS8IlAl7nTeFr07ukJgo=
 github.com/ONSdigital/dp-component-test v0.7.0 h1:VfAxUPDSSt106qxDVF9NQ/5S9GwJaiMDpwhQZ9lybOM=
 github.com/ONSdigital/dp-component-test v0.7.0/go.mod h1:6nvnxyPDFxEhVVIciXdMJ5e2nG8wS8XGhciCtuan5xo=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=


### PR DESCRIPTION
### What

added extra param to specify lang and pointed at dp-api-clients-go to feature/cantabular-metadata-runtime-terror3

### How to review

`make debug`

and

`curl  -X GET http://localhost:28300/dataset/LC2101EW/cantabular/Teaching-Dataset/lang/cy -H 'accept: application/json' -H 'Content-Type: application/json'|jq .`

should return Welsh (mostly)

### Who can review

Anyone