### PR TITLE
add cantabular health check from existing code 

### DIFF
--- a/service/service_test.go
+++ b/service/service_test.go
@@ -127,7 +127,7 @@ func TestRun(t *testing.T) {
 
 			Convey("The checkers are registered and the healthcheck and http server started", func() {
 				So(hcMock.AddCheckCalls(), ShouldHaveLength, 1)
-				So(hcMock.AddCheckCalls()[0].Name, ShouldResemble, "dataset-api")
+				So(hcMock.AddCheckCalls()[0].Name, ShouldResemble, "cantabular-api-ext")
 				// TODO: reinstate when find out from SCC what endpoint to check
 				// So(hcMock.AddCheckCalls()[1].Name, ShouldResemble, "cantabular-api-ext")
 				So(initMock.DoGetHTTPServerCalls(), ShouldHaveLength, 1)


### PR DESCRIPTION
### What

add cantabular health check from existing code & remove dataset-api healthcheck

### How to review

"make debug" should report logs about "check for cantabular-api-ext" (either positive or negative depending on whether you have  cantabular-api-ext running on port 8492)

Tests should pass

### Who can review

Anyone