### PR TITLE
use cantabular metadata server directly rather than through ext-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Supply Cantabular metadata for Florence metadata journey.
 | GRACEFUL_SHUTDOWN_TIMEOUT    | 5s        | The graceful shutdown timeout in seconds (`time.Duration` format)
 | HEALTHCHECK_INTERVAL         | 30s       | Time between self-healthchecks (`time.Duration` format)
 | HEALTHCHECK_CRITICAL_TIMEOUT | 90s       | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
-| CANTABULAR_EXT_API_URL       | :8492     | Host and port for `dp-cantabular-api-ext`
+| CANTABULAR_METADATA_URL      | :8493     | Host and port for `dp-cantabular-metadata-service`
 
 ### Contributing
 

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
-	CantabularExtURL           string        `envconfig:"CANTABULAR_EXT_API_URL"`
+	CantabularMetadataURL      string        `envconfig:"CANTABULAR_METADATA_URL"`
 	ServiceAuthToken           string        `envconfig:"SERVICE_AUTH_TOKEN"               json:"-"`
 }
 
@@ -30,7 +30,7 @@ func Get() (*Config, error) {
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
-		CantabularExtURL:           "http://localhost:8492",
+		CantabularMetadataURL:      "http://localhost:8493",
 		ServiceAuthToken:           "FD0108EA-825D-411C-9B1D-41EF7727F465",
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,7 +28,7 @@ func TestConfig(t *testing.T) {
 					GracefulShutdownTimeout:    5 * time.Second,
 					HealthCheckInterval:        30 * time.Second,
 					HealthCheckCriticalTimeout: 90 * time.Second,
-					CantabularExtURL:           "http://localhost:8492",
+					CantabularMetadataURL:      "http://localhost:8493",
 					ServiceAuthToken:           "FD0108EA-825D-411C-9B1D-41EF7727F465",
 				})
 			})

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ go 1.18
 replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
 
 require (
-	// point dp-api-clients-go at feature/cantabular-metadata-runtime-terror4 branch which we don't want to merge yet
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.142.1-0.20220617134822-b2030e977e56
+	// point dp-api-clients-go at feature/md-server-direct branch which we don't want to merge yet
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.142.1-0.20220630123729-a2105bd509a7
 	github.com/ONSdigital/dp-component-test v0.7.0
 	github.com/ONSdigital/dp-healthcheck v1.3.0
 	github.com/ONSdigital/dp-net v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.142.1-0.20220617134822-b2030e977e56 h1:cmYMSjSxXbl4Tc8mJdN5o8RT6u6eblM2ZS2OzeXthU0=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.142.1-0.20220617134822-b2030e977e56/go.mod h1:G5FKuWcW/bOvKS7auRZLJ79kXIRFKlIxyr8+uFjzBtU=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.142.1-0.20220630123729-a2105bd509a7 h1:usxZU2mpQ+OK/PEmP3OazoYUvVrQbOpFmMUpkEqWAt8=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.142.1-0.20220630123729-a2105bd509a7/go.mod h1:G5FKuWcW/bOvKS7auRZLJ79kXIRFKlIxyr8+uFjzBtU=
 github.com/ONSdigital/dp-component-test v0.7.0 h1:VfAxUPDSSt106qxDVF9NQ/5S9GwJaiMDpwhQZ9lybOM=
 github.com/ONSdigital/dp-component-test v0.7.0/go.mod h1:6nvnxyPDFxEhVVIciXdMJ5e2nG8wS8XGhciCtuan5xo=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=

--- a/service/service.go
+++ b/service/service.go
@@ -36,7 +36,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 
 	s := serviceList.GetHTTPServer(cfg.BindAddr, r)
 
-	c := cantabular.NewClient(cantabular.Config{ExtApiHost: cfg.CantabularExtURL}, dphttp.NewClient(), nil)
+	c := cantabular.NewClient(cantabular.Config{ExtApiHost: cfg.CantabularMetadataURL}, dphttp.NewClient(), nil)
 
 	// Setup the API
 	a := api.Setup(ctx, r, cfg, c)


### PR DESCRIPTION
### What

Use Cantabular metadata service as endpoint rather the Cantabular ext api which indirectly accesses it

This needs change in the front end since the returned JSON structure is slightly different. The returned "Variables" are now "Vars" and a flatter, neater structure. This also allows use of mock data for 2021 metadata to be easier.

### How to review

Changes look sane and ideally are tested against a new florence branch which populates the variables (dimensions)

### Who can review

Anyone in RTT metadata sub-team
